### PR TITLE
fix: default compilation when retrieving the classpath

### DIFF
--- a/dspot/src/main/java/eu/stamp_project/automaticbuilder/maven/MavenAutomaticBuilder.java
+++ b/dspot/src/main/java/eu/stamp_project/automaticbuilder/maven/MavenAutomaticBuilder.java
@@ -72,13 +72,14 @@ public class MavenAutomaticBuilder implements AutomaticBuilder {
             DSpotPOMCreator.createNewPomForComputingClassPathWithParallelExecution();
             pomPathname = InputConfiguration.get().getAbsolutePathToProjectRoot()
                     + DSpotPOMCreator.getParallelPOMName();
+            this.hasGeneratePom = true;
+            LOGGER.info("Using {} to run maven.", pomPathname);
+            return _runGoals(true, pomPathname, goals);
         } else {
-            DSpotPOMCreator.createNewPom();
-            pomPathname = InputConfiguration.get().getAbsolutePathToProjectRoot() + DSpotPOMCreator.getPOMName();
+            pomPathname = InputConfiguration.get().getAbsolutePathToProjectRoot() + DSpotPOMCreator.POM_FILE;
+            LOGGER.info("Using {} to run maven.", pomPathname);
+            return _runGoals(false, pomPathname, goals);
         }
-        this.hasGeneratePom = true;
-        LOGGER.info("Using {} to run maven.", pomPathname);
-        return _runGoals(true, pomPathname, goals);
     }
 
 

--- a/dspot/src/main/java/eu/stamp_project/dspot/assertgenerator/AssertGenerator.java
+++ b/dspot/src/main/java/eu/stamp_project/dspot/assertgenerator/AssertGenerator.java
@@ -110,7 +110,7 @@ public class AssertGenerator {
         final TestResult testResult;
         try {
             //Add parallel test execution support (JUnit4, JUnit5) for execution method (CMD, Maven)
-            CloneHelper.addParallelExecutionAnnotation (testClass, tests);
+            CloneHelper.addParallelExecutionAnnotation(testClass, tests);
             testResult = TestCompiler.compileAndRun(testClass,
                     this.compiler,
                     tests,

--- a/dspot/src/main/java/eu/stamp_project/utils/CloneHelper.java
+++ b/dspot/src/main/java/eu/stamp_project/utils/CloneHelper.java
@@ -27,17 +27,19 @@ public class CloneHelper {
     }
 
     public static void addParallelExecutionAnnotation(CtType clone, List<CtMethod<?>> tests) {
-        if (TestFramework.isJUnit5(tests.get(0))) {
-            addJUnit5ParallelExecutionAnnotation(clone);
-        }else {
-            addJUnit4ParallelExecutionAnnotation(clone);
+        if (InputConfiguration.get().shouldExecuteTestsInParallel()) {
+            if (TestFramework.isJUnit5(tests.get(0))) {
+                addJUnit5ParallelExecutionAnnotation(clone);
+            } else {
+                addJUnit4ParallelExecutionAnnotation(clone);
+            }
         }
     }
 
     public static void removeParallelExecutionAnnotation(CtType clone, List<CtMethod<?>> tests) {
         if (TestFramework.isJUnit5(tests.get(0))) {
             removeJUnit5ParallelExecutionAnnotation(clone);
-        }else {
+        } else {
             removeJUnit4ParallelExecutionAnnotation(clone);
         }
     }
@@ -54,7 +56,7 @@ public class CloneHelper {
         CtAnnotation existing_annotation = clone.getAnnotations().stream()
                 .filter(annotation -> annotation.toString().contains(label))
                 .findFirst().orElse(null);
-        if (existing_annotation!=null) {
+        if (existing_annotation != null) {
             clone.removeAnnotation(existing_annotation);
         }
     }
@@ -63,7 +65,7 @@ public class CloneHelper {
         CtAnnotation existing_annotation = clone.getAnnotations().stream()
                 .filter(annotation -> annotation.toString().contains("RunWith"))
                 .findFirst().orElse(null);
-        if (existing_annotation==null) {
+        if (existing_annotation == null) {
             CtAnnotation<Annotation> annotation =
                     factory.Code().createAnnotation(factory.Code().createCtTypeReference(org.junit.runner.RunWith.class));
             annotation.addValue("value", ParallelRunner.class);
@@ -75,7 +77,7 @@ public class CloneHelper {
         CtAnnotation existing_annotation = clone.getAnnotations().stream()
                 .filter(annotation -> annotation.toString().contains("Execution"))
                 .findFirst().orElse(null);
-        if (existing_annotation==null) {
+        if (existing_annotation == null) {
             CtAnnotation<Annotation> annotation =
                     factory.Code().createAnnotation(factory.Code().createCtTypeReference(org.junit.jupiter.api.parallel.Execution.class));
             annotation.addValue("value", org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT);


### PR DESCRIPTION
This pr attempts to fix the test suite.

However, I'm afraid that for the parallelization we have a problem.

In fact, we are injecting dependencies into the pom required to execute tests in parallel right? 

What we must do is:

1. The first compilation is done using the default `pom`
2. We pull the required dependencies
3. The String contains the path to these dependencies while it is build using the default `pom`.